### PR TITLE
Replace Exception with Custom Error And Fix Lock Release Bug

### DIFF
--- a/lib/ruby_redis_lock/ruby_redis_lock.rb
+++ b/lib/ruby_redis_lock/ruby_redis_lock.rb
@@ -1,66 +1,56 @@
 module RubyRedisLock
-  
+
+  LockAcquisitionTimeoutException = Class.new(StandardError)
 
   def lock(lock_name, processing_timeout=60, acquiring_timout=10)
-    acquire_lock(lock_name, processing_timeout, acquiring_timout)
+    lock_acquired = acquire_lock(lock_name, processing_timeout, acquiring_timout)
     yield
   ensure
-    release_lock(lock_name, processing_timeout)
+    release_lock(lock_name, processing_timeout) if lock_acquired
   end
-  
-  
-  private
-    def acquire_lock(lock_name, processing_timeout=60, acquiring_timeout=10)
-      
-      start_time = Time.now.to_i
-      
-      while !try_acquire_lock(lock_name, processing_timeout)
-      
-        sleep(rand(100).to_f/100.0)
-      
-        if (Time.now.to_i - start_time) > acquiring_timeout
-          raise Exception, "Acquiring lock timeout > #{acquiring_timeout} seconds"
-        end
-        
-      end
-      
-      return true
-    
-    end
-  
-    def try_acquire_lock(lock_name, processing_timeout=60)
-      
-      ret = self.setnx(ruby_redis_lock_key(lock_name), "#{Time.now.to_i + processing_timeout}")
-      return true if ret == true
-      
-      expiration = self.get(ruby_redis_lock_key(lock_name)).to_i
-      return false if Time.now.to_i < expiration
 
-      previous_expiration = self.getset(ruby_redis_lock_key(lock_name), "#{Time.now.to_i + processing_timeout}").to_i
-      return true if expiration == previous_expiration
-      
-      return false
-      
-    end
-    
-    def release_lock(lock_name, processing_timeout=60)
-      
-      expiration = self.get(ruby_redis_lock_key(lock_name)).to_i
-      return false if Time.now.to_i > expiration
-      
-      previous_expiration = self.getset(ruby_redis_lock_key(lock_name), "#{Time.now.to_i + processing_timeout}").to_i
-      
-      if expiration == previous_expiration # it still owns the lock
-        self.del(ruby_redis_lock_key(lock_name))
-        return true
+  private
+
+  def acquire_lock(lock_name, processing_timeout=60, acquiring_timeout=10)
+    start_time = Time.now.to_i
+    while !try_acquire_lock(lock_name, processing_timeout)
+      sleep 0.5
+      if (Time.now.to_i - start_time) > acquiring_timeout
+        raise LockAcquisitionTimeoutException, "Acquiring lock timeout > #{acquiring_timeout} seconds"
       end
-      
-      return false
     end
-  
-    def ruby_redis_lock_key(lock_name)
-      "RubyRedisLock:#{lock_name}"
+    true
+  end
+
+  def try_acquire_lock(lock_name, processing_timeout=60)
+    ret = self.setnx(ruby_redis_lock_key(lock_name), "#{Time.now.to_i + processing_timeout}")
+    return true if ret == true
+
+    expiration = self.get(ruby_redis_lock_key(lock_name)).to_i
+    return false if Time.now.to_i < expiration
+
+    previous_expiration = self.getset(ruby_redis_lock_key(lock_name), "#{Time.now.to_i + processing_timeout}").to_i
+    return true if expiration == previous_expiration
+
+    false
+  end
+
+  def release_lock(lock_name, processing_timeout=60)
+    expiration = self.get(ruby_redis_lock_key(lock_name)).to_i
+    return false if Time.now.to_i > expiration
+
+    previous_expiration = self.getset(ruby_redis_lock_key(lock_name), "#{Time.now.to_i + processing_timeout}").to_i
+
+    if expiration == previous_expiration # it still owns the lock
+      self.del(ruby_redis_lock_key(lock_name))
+      return true
     end
-  
+
+    false
+  end
+
+  def ruby_redis_lock_key(lock_name)
+    "RubyRedisLock:#{lock_name}"
+  end
 
 end


### PR DESCRIPTION
There was a bug where calling $redis.lock would release the lock even if it never acquired it. The result was that the first time an attempt is made to acquire a busy lock would fail, but then the lock would release. From then on, subsequent calls to #lock would successfully seize the lock when they should not.

Exception is the broadest error class in ruby. By explicitly raising Exception, developers are forced to rescue Exception in order to implement logic for handling timeouts, which is dangerous. Here, it's been replaced with a much safer custom error.